### PR TITLE
Small makefile fix

### DIFF
--- a/src_cpp/Makefile
+++ b/src_cpp/Makefile
@@ -77,8 +77,8 @@ ifeq ($(origin CXX),default)
 CXX=mpiicpc
 endif
 override CPPFLAGS += -I.
-override CFLAGS += -O0 -Wall -Wextra -pedantic -Wno-long-long
-override CXXFLAGS += -O0 -Wall -Wextra -pedantic -Wno-long-long
+override CFLAGS += -O2 -Wall -Wno-long-long
+override CXXFLAGS += -O2 -Wall -Wextra -pedantic -Wno-long-long
 ifdef WITH_OPENMP
 override CFLAGS += -fopenmp
 override CXXFLAGS += -fopenmp

--- a/src_cpp/Makefile
+++ b/src_cpp/Makefile
@@ -58,6 +58,8 @@ endif
 ifndef TARGET
 TARGET=example
 ANNOUNCE=1
+else
+ANNOUNCE=0
 endif
 
 ifdef TARGET
@@ -171,8 +173,8 @@ override CPPFLAGS += -DWITH_YAML_CPP
 endif
 
 announce:
-	@if [ "$(ANNOUNCE)" == "1" ]; then echo "NOTE: Building target: $(TARGET), binary name: $(BINARY)"; fi
-	@if [ "$(ANNOUNCE)" == "1" ]; then echo "NOTE: Use make TARGET=<DIR_NAME> to select a target suite"; fi
+	@if test "$(ANNOUNCE)" -eq "1"; then echo "NOTE: Building target: $(TARGET), binary name: $(BINARY)"; fi
+	@if test "$(ANNOUNCE)" -eq "1"; then echo "NOTE: Use make TARGET=<DIR_NAME> to select a target suite"; fi
 
 $(BINARY): $(IMB_OBJ) $(BECHMARK_SUITE_OBJ) $(ADDITIONAL_OBJ) $(YAML_CPP_LIB)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)


### PR DESCRIPTION
Here are two small fixes for a main Makefile placed in the src_cpp/ directory.
1. Shell command syntax in announcement target rules are not portable, so they may fail on some systems. The offered replacement uses older shell syntax to make sure it works everywhere.
2. There was -O0 optimization flag which is looks odd for release software; the -Wextra and -pedantic flags for C-files produce a lot of growling from compiler on legacy IMB code which is probably of no use since this code hardly is going to develop anymore. If these flags are removed, there are much less warnings (at least on on GCC 4.7).