### PR TITLE
MPI_Reduce_scatter[_block] fix the receive buffer size.

### DIFF
--- a/src_c/IMB_reduce_scatter.c
+++ b/src_c/IMB_reduce_scatter.c
@@ -140,7 +140,7 @@ Output variables:
     MPI_Type_size(c_info->red_data_type, &s_size);
 
     for (i = 0; i < c_info->num_procs; i++) {
-        c_info->reccnt[i] = size / s_size;
+        c_info->reccnt[i] = ((size / s_size) * (i+1) / c_info->num_procs) - ((size / s_size) * i / c_info->num_procs); 
     }
 #ifdef CHECK
     Locsize = s_size * c_info->reccnt[c_info->rank];

--- a/src_c/IMB_reduce_scatter_block.c
+++ b/src_c/IMB_reduce_scatter_block.c
@@ -137,7 +137,7 @@ Output variables:
     /*  GET SIZE OF DATA TYPE */
     MPI_Type_size(c_info->red_data_type, &s_size);
 
-    s_num = size / s_size;
+    s_num = size / s_size / c_info->num_procs;
 #ifdef CHECK
     Locsize = s_size * s_num;
     pos = Locsize * c_info->rank;


### PR DESCRIPTION
In the case of MPI_Reduce_scatter(), the sum of all the recvcounts
should be equal to the number of elements in the send buffer.

In the case of MPI_Reduce_scatter_block(), recvcount * comm_size
should be equal to the number of elements in the send buffer.

This issue was initially reported by Simon David Hammond at
https://www.mail-archive.com/users@lists.open-mpi.org/msg32889.html