### PR TITLE
Added a missing `const` qualifier

### DIFF
--- a/src_cpp/args_parser.h
+++ b/src_cpp/args_parser.h
@@ -216,7 +216,7 @@ class args_parser {
     protected:
     std::set<flag_t> flags;
     std::string current_group;
-    std::map<std::string, std::vector<smart_ptr<option> > > expected_args;
+    std::map<const std::string, std::vector<smart_ptr<option> > > expected_args;
     std::vector<std::string> unknown_args;
     option *prev_option;
     error_t last_error;


### PR DESCRIPTION
The type of [`args_parser::expected_args`](https://github.com/intel/mpi-benchmarks/blob/IMB-v2019.2/src_cpp/args_parser.h#L219) and the type of [`it` in `args_parser::in_expected_args`](https://github.com/intel/mpi-benchmarks/blob/IMB-v2019.2/src_cpp/args_parser.cpp#L310) are incompatible. The former lacks `const`. This causes a compilation error with libc++ (e.g. use `clang++` with `CXXFLAGS=-stdlib=libc++`).

My colleague [reported](https://bugs.llvm.org/show_bug.cgi?id=40755) this as a bug of libc++ but a maintainer answered that this is a bug in IMB.
