### PR TITLE
Reordered bodies of `BENCHMARK` macros

### DIFF
--- a/src_cpp/EXT/EXT_benchmark.cpp
+++ b/src_cpp/EXT/EXT_benchmark.cpp
@@ -70,9 +70,10 @@ extern "C" {
 
 using namespace std;
 
-#define BENCHMARK(BMRK_FN, BMRK_NAME) template class OriginalBenchmark<BenchmarkSuite<BS_EXT>, BMRK_FN>; \
-DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME(OriginalBenchmark<BenchmarkSuite<BS_EXT>, BMRK_FN>), BMRK_NAME) \
+#define BENCHMARK(BMRK_FN, BMRK_NAME) \
 template<> smart_ptr<Bmark_descr> OriginalBenchmark<BenchmarkSuite<BS_EXT>, BMRK_FN>::descr = NULL; \
+DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME(OriginalBenchmark<BenchmarkSuite<BS_EXT>, BMRK_FN>), BMRK_NAME) \
+template class OriginalBenchmark<BenchmarkSuite<BS_EXT>, BMRK_FN>; \
 template<> bool OriginalBenchmark<BenchmarkSuite<BS_EXT>, BMRK_FN>::init_description() 
 
 BENCHMARK(IMB_window, Window)

--- a/src_cpp/IO/IO_benchmark.cpp
+++ b/src_cpp/IO/IO_benchmark.cpp
@@ -70,9 +70,10 @@ extern "C" {
 
 using namespace std;
 
-#define BENCHMARK(BMRK_FN, BMRK_NAME) template class OriginalBenchmark<BenchmarkSuite<BS_IO>, BMRK_FN>; \
-DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME(OriginalBenchmark<BenchmarkSuite<BS_IO>, BMRK_FN>), BMRK_NAME) \
+#define BENCHMARK(BMRK_FN, BMRK_NAME) \
 template<> smart_ptr<Bmark_descr> OriginalBenchmark<BenchmarkSuite<BS_IO>, BMRK_FN>::descr = NULL; \
+DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME(OriginalBenchmark<BenchmarkSuite<BS_IO>, BMRK_FN>), BMRK_NAME) \
+template class OriginalBenchmark<BenchmarkSuite<BS_IO>, BMRK_FN>; \
 template<> bool OriginalBenchmark<BenchmarkSuite<BS_IO>, BMRK_FN>::init_description() 
 
 BENCHMARK(IMB_write_indv, S_Write_Indv)

--- a/src_cpp/MPI1/MPI1_benchmark.cpp
+++ b/src_cpp/MPI1/MPI1_benchmark.cpp
@@ -70,10 +70,11 @@ extern "C" {
 
 using namespace std;
 
-#define BENCHMARK(BMRK_FN, BMRK_NAME) template class OriginalBenchmark<BenchmarkSuite<BS_MPI1>, BMRK_FN>; \
-DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME(OriginalBenchmark<BenchmarkSuite<BS_MPI1>, BMRK_FN>), BMRK_NAME) \
+#define BENCHMARK(BMRK_FN, BMRK_NAME) \
 template<> smart_ptr<Bmark_descr> OriginalBenchmark<BenchmarkSuite<BS_MPI1>, BMRK_FN>::descr = NULL; \
-template<> bool OriginalBenchmark<BenchmarkSuite<BS_MPI1>, BMRK_FN>::init_description() 
+DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME(OriginalBenchmark<BenchmarkSuite<BS_MPI1>, BMRK_FN>), BMRK_NAME) \
+template class OriginalBenchmark<BenchmarkSuite<BS_MPI1>, BMRK_FN>; \
+template<> bool OriginalBenchmark<BenchmarkSuite<BS_MPI1>, BMRK_FN>::init_description()
 
 
 BENCHMARK(IMB_pingpong, PingPong)

--- a/src_cpp/MT/MT_benchmark.cpp
+++ b/src_cpp/MT/MT_benchmark.cpp
@@ -73,12 +73,14 @@ goods and services.
         return OLDNAME(repeat, skip, in, out, count, type, comm, rank, size, idata, odata); \
     }
 
-#define DECLARE_INHERITED_BENCHMARKMT2(BS, FUNC, NAME) template class BenchmarkMT<BS, FUNC>; \
+#define DECLARE_INHERITED_BENCHMARKMT2(BS, FUNC, NAME) \
     DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME3(BenchmarkMT<BS, FUNC>), NAME)                  \
+    template class BenchmarkMT<BS, FUNC>;                                                    \
     template <> void BenchmarkMT<BS, FUNC >::init_flags()
 
-#define DECLARE_INHERITED_BENCHMARKMT(BS, FUNC, NAME) template class BenchmarkMT<BS, FUNC>; \
+#define DECLARE_INHERITED_BENCHMARKMT(BS, FUNC, NAME) \
     DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME2(BenchmarkMT<BS, FUNC>), NAME)                 \
+    template class BenchmarkMT<BS, FUNC>;                                                   \
     template <> void BenchmarkMT<BS, FUNC >::init_flags()
 
 

--- a/src_cpp/NBC/NBC_benchmark.cpp
+++ b/src_cpp/NBC/NBC_benchmark.cpp
@@ -70,9 +70,10 @@ extern "C" {
 
 using namespace std;
 
-#define BENCHMARK(BMRK_FN, BMRK_NAME) template class OriginalBenchmark<BenchmarkSuite<BS_NBC>, BMRK_FN>; \
-DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME(OriginalBenchmark<BenchmarkSuite<BS_NBC>, BMRK_FN>), BMRK_NAME) \
+#define BENCHMARK(BMRK_FN, BMRK_NAME) \
 template<> smart_ptr<Bmark_descr> OriginalBenchmark<BenchmarkSuite<BS_NBC>, BMRK_FN>::descr = NULL; \
+DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME(OriginalBenchmark<BenchmarkSuite<BS_NBC>, BMRK_FN>), BMRK_NAME) \
+template class OriginalBenchmark<BenchmarkSuite<BS_NBC>, BMRK_FN>; \
 template<> bool OriginalBenchmark<BenchmarkSuite<BS_NBC>, BMRK_FN>::init_description() 
 
 BENCHMARK(IMB_ibcast, Ibcast)

--- a/src_cpp/RMA/RMA_benchmark.cpp
+++ b/src_cpp/RMA/RMA_benchmark.cpp
@@ -70,9 +70,10 @@ extern "C" {
 
 using namespace std;
 
-#define BENCHMARK(BMRK_FN, BMRK_NAME) template class OriginalBenchmark<BenchmarkSuite<BS_RMA>, BMRK_FN>; \
-DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME(OriginalBenchmark<BenchmarkSuite<BS_RMA>, BMRK_FN>), BMRK_NAME) \
+#define BENCHMARK(BMRK_FN, BMRK_NAME) \
 template<> smart_ptr<Bmark_descr> OriginalBenchmark<BenchmarkSuite<BS_RMA>, BMRK_FN>::descr = NULL; \
+DECLARE_INHERITED_TEMPLATE(GLUE_TYPENAME(OriginalBenchmark<BenchmarkSuite<BS_RMA>, BMRK_FN>), BMRK_NAME) \
+template class OriginalBenchmark<BenchmarkSuite<BS_RMA>, BMRK_FN>; \
 template<> bool OriginalBenchmark<BenchmarkSuite<BS_RMA>, BMRK_FN>::init_description() 
 
 


### PR DESCRIPTION
The bodies of the `BENCHMARK` macros in `src_cpp/*/*_benchmark.cpp` is wrongly ordered. For example, `BENCHMARK(IMB_pingpong, PingPong)` is expaneded as the following code. `elem_PingPong` is instantiated before `name` and `descr` are specialized.

```c++
template class OriginalBenchmark<BenchmarkSuite<BS_MPI1>, IMB_pingpong>;
namespace { OriginalBenchmark<BenchmarkSuite<BS_MPI1>,IMB_pingpong> elem_PingPong; }
template<> const char *OriginalBenchmark<BenchmarkSuite<BS_MPI1>,IMB_pingpong>::name = "PingPong";
template<> smart_ptr<Bmark_descr> OriginalBenchmark<BenchmarkSuite<BS_MPI1>, IMB_pingpong>::descr = __null;
template<> bool OriginalBenchmark<BenchmarkSuite<BS_MPI1>, IMB_pingpong>::init_description()
```

This causes the following compilation error with `clang++`.

```
MPI1/MPI1_benchmark.cpp:79:1: error: explicit specialization of 'name' after instantiation
BENCHMARK(IMB_pingpong, PingPong)
^
MPI1/MPI1_benchmark.cpp:73:107: note: expanded from macro 'BENCHMARK'
#define BENCHMARK(BMRK_FN, BMRK_NAME) template class OriginalBenchmark<BenchmarkSuite<BS_MPI1>, BMRK_FN>; \
                                                                                                          ^
./benchmark.h:88:114: note: expanded from macro '\
DECLARE_INHERITED_TEMPLATE'
#define DECLARE_INHERITED_TEMPLATE(CLASS, NAME) namespace { CLASS elem_ ## NAME; } template<> const char *CLASS::name = #NAME;
                                                                                                                 ^
helpers/original_benchmark.h:139:34: note: implicit instantiation first required here
            BMark->name = strdup(name);
                                 ^
```
