### PR TITLE
Fix buffer overflow in snprintf

### DIFF
--- a/src_c/IMB_declare.c
+++ b/src_c/IMB_declare.c
@@ -74,7 +74,7 @@ char* dbgf_name;
 double *all_times;
 
 /*  STRINGS FOR OUTPUT   */
-char aux_string[out_fields*ow_format];
+char aux_string[AUX_STRING_SIZE];
 
 /* FORMAT FOR OUTPUT    */
 char format [out_fields*7];

--- a/src_c/IMB_declare.h
+++ b/src_c/IMB_declare.h
@@ -200,7 +200,8 @@ typedef struct {
 extern double *all_times;
 
 /* STRING FOR OUTPUT    */
-extern char aux_string[out_fields*ow_format];
+#define AUX_STRING_SIZE (out_fields*ow_format+128)
+extern char aux_string[AUX_STRING_SIZE];
 
 /* FORMAT FOR OUTPUT    */
 extern char format    [out_fields*7];


### PR DESCRIPTION
IMB_display_times writes a string of size 106 into a buffer of size 104 and even using an offset which will make this worse by writing even further out of bounds. Increase the buffer size by a constant to avoid this.

```
 ../src_c/IMB_output.c: In Funktion »IMB_display_times«:
 ../src_c/IMB_output.c:346:152: Fehler: » int-overflow; The productio...«-Direktive schreibt 106 Bytes in eine Region der Größe 104 [-Werror=format-overflow=]
   346 |                 sprintf(aux_string + offset, " int-overflow; The production rank*size caused int overflow for given sample; use flag \"-data_type double\"");
       |                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
 ../src_c/IMB_output.c:346:17: Anmerkung: »sprintf« hat 107 Byte in ein Ziel der Größe 104 ausgegeben
   346 |                 sprintf(aux_string + offset, " int-overflow; The production rank*size caused int overflow for given sample; use flag \"-data_type double\"");
       |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```