### PR TITLE
src_c/IMB_chk_diff.c: Remove unused rank variable

### DIFF
--- a/src_c/IMB_chk_diff.c
+++ b/src_c/IMB_chk_diff.c
@@ -459,7 +459,7 @@ Output variables:
     MPI_File    restore;
     MPI_Status  stat;
     double      def_tmp;
-    int         j, j1, j2, ierr, rank, allpos;
+    int         j, j1, j2, ierr, allpos;
     size_t      pos1, pos2;
     int*        rankj;
     size_t*     lenj;


### PR DESCRIPTION
This fixes the compilation error on unused variable.

```
make[1]: Leaving directory '/home/ubuntu/PortaFiducia/build/workloads/imb/mpi-benchmarks/src_cpp'
../src_c/IMB_chk_diff.c: In function ‘IMB_chk_diff’:
../src_c/IMB_chk_diff.c:462:34: error: unused variable ‘rank’ [-Werror=unused-variable]
  462 |     int         j, j1, j2, ierr, rank, allpos;
      |                                  ^~~~
mpicc -g -O0 -Wall -Werror -DCHECK -Ihelpers -I../src_c -DNBC -I. -DNBC -c -o NBC/IMB_reduce.o ../src_c/IMB_reduce.
```