### PR TITLE
Fix compilation with MPI-4.0: replace deprecated MPI_Info_get APIs

### DIFF
--- a/src_c/IMB_output.c
+++ b/src_c/IMB_output.c
@@ -823,11 +823,18 @@ void IMB_print_info() {
         for (ikey = 0; ikey < nkeys; ikey++) {
             MPI_Info_get_nthkey(tmp_info, ikey, key);
 
+#if MPI_VERSION >= 4
+            vlen = 0;
+            MPI_Info_get_string(tmp_info, key, &vlen, NULL, &exists);
+            value = (char*)IMB_v_alloc(vlen * sizeof(char), "Print_Info");
+            MPI_Info_get_string(tmp_info, key, &vlen, value, &exists);
+#else
             MPI_Info_get_valuelen(tmp_info, key, &vlen, &exists);
 
             value = (char*)IMB_v_alloc((vlen + 1)* sizeof(char), "Print_Info");
 
             MPI_Info_get(tmp_info, key, vlen, value, &exists);
+#endif
             printf("# %s = \"%s\"\n", key, value);
 
             IMB_v_free((void**)&value);


### PR DESCRIPTION
MPI_Info_get and MPI_Info_get_valuelen were deprecated in MPI-4.0 (replaced by MPI_Info_get_string). When building IMB against an MPI implementation that marks these with [[deprecated]] attributes (e.g., OpenMPI main v6.1.0a1), compilation fails under -Werror=deprecated-declarations.

Add a #if MPI_VERSION >= 4 gate in IMB_print_info() to use MPI_Info_get_string on MPI-4.0+ while preserving the original calls for older implementations.