### PR TITLE
Allocate the auxiliary arrays needed for MPIIO builds

### DIFF
--- a/src_c/IMB_mem_manager.c
+++ b/src_c/IMB_mem_manager.c
@@ -424,7 +424,7 @@ In/Out     : c_info   | struct comm_info* | see comm_info.h
     IMB_i_alloc(int, c_info->g_ranks, c_info->w_num_procs, "Init_Pointers 1");
     IMB_i_alloc(int, c_info->g_sizes, c_info->w_num_procs, "Init_Pointers 2");
 
-#if (defined MPI1 || defined NBC || defined MPI4)
+#if (defined MPI1 || defined NBC || defined MPI4 || defined MPIIO)
     IMB_i_alloc(int, c_info->sndcnt, c_info->w_num_procs, "Init_Pointers 3");
     IMB_i_alloc(int, c_info->sdispl, c_info->w_num_procs, "Init_Pointers 4");
 


### PR DESCRIPTION
With CHECK_RESULTS enabled, IMB-IO-openmpi P_Write_Shared crashes on the first non-zero message size because IMB_chk_distr() uses reccnt, while IMB_init_pointers() leaves it NULL for MPIIO builds.